### PR TITLE
Reduce image sizes and fix comment

### DIFF
--- a/containers/ffmpeg/Dockerfile
+++ b/containers/ffmpeg/Dockerfile
@@ -5,15 +5,7 @@ FROM resin/rpi-raspbian
 MAINTAINER Benjamin Maynard <benjamin@maynard.io>
 
 # Install Essential Packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libpcre3 libpcre3-dev libssl-dev build-essential make gcc libpcre++-dev zlib1g-dev libbz2-dev libxslt1-dev libxml2-dev libgd2-xpm-dev libgeoip-dev libgoogle-perftools-dev libperl-dev libcurl4-openssl-dev git libpcre3-dev libavfilter-dev libavformat-dev libavcodec-dev libomxil-bellagio-dev libraspberrypi-bin
-
-# Clone FFmpeg, Build and Install
-WORKDIR /root
-RUN git clone https://github.com/FFmpeg/FFmpeg.git
-WORKDIR /root/FFmpeg
-RUN ./configure --enable-cross-compile --cross-prefix=${CCPREFIX} --arch=armel --target-os=linux --enable-gpl --enable-omx --enable-omx-rpi --enable-nonfree
-RUN make -j4
-RUN make install
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libpcre3 libpcre3-dev libssl-dev build-essential make gcc libpcre++-dev zlib1g-dev libbz2-dev libxslt1-dev libxml2-dev libgd2-xpm-dev libgeoip-dev libgoogle-perftools-dev libperl-dev libcurl4-openssl-dev git libpcre3-dev libavfilter-dev libavformat-dev libavcodec-dev libomxil-bellagio-dev libraspberrypi-bin && cd /root && git clone https://github.com/FFmpeg/FFmpeg.git && cd /root/FFmpeg && ./configure --enable-cross-compile --cross-prefix=${CCPREFIX} --arch=armel --target-os=linux --enable-gpl --enable-omx --enable-omx-rpi --enable-nonfree && make -j4 && make install && cd / && rm -rf /root/FFmpeg && apt-get remove --purge -y build-essential libssl-dev build-essential make gcc libpcre++-dev zlib1g-dev libbz2-dev libxslt1-dev libxml2-dev libgd2-xpm-dev libgeoip-dev libgoogle-perftools-dev libperl-dev libcurl4-openssl-dev git && apt-get autoremove --purge -y && rm -rf /var/lib/apt/lists/*
 
 # Set EntryPoint Script
 COPY resources/entrypoint.sh /

--- a/containers/nginx-rtsp/Dockerfile
+++ b/containers/nginx-rtsp/Dockerfile
@@ -5,21 +5,7 @@ FROM resin/rpi-raspbian
 MAINTAINER Benjamin Maynard <benjamin@maynard.io>
 
 # Install Essential Packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libpcre3 libpcre3-dev libssl-dev build-essential make gcc libpcre++-dev zlib1g-dev libbz2-dev libxslt1-dev libxml2-dev libgd2-xpm-dev libgeoip-dev libgoogle-perftools-dev libperl-dev libcurl4-openssl-dev git
-
-# Clone Nginx, RTMP Module, and Build
-WORKDIR /root
-RUN git clone https://github.com/sergey-dryabzhinsky/nginx-rtmp-module.git
-RUN curl -o nginx.tar.gz http://nginx.org/download/nginx-1.14.0.tar.gz
-RUN mkdir nginx
-RUN tar xf nginx.tar.gz -C nginx --strip-components 1
-WORKDIR /root/nginx
-RUN ./configure --with-http_ssl_module --add-module=../nginx-rtmp-module && make -j 1 && make install
-
-# Remove Source Code
-RUN rm -rf /root/nginx
-RUN rm -rf /root/nginx-rtmp-module
-RUN rm /root/nginx.tar.gz
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libpcre3 libpcre3-dev libssl-dev build-essential make gcc libpcre++-dev zlib1g-dev libbz2-dev libxslt1-dev libxml2-dev libgd2-xpm-dev libgeoip-dev libgoogle-perftools-dev libperl-dev libcurl4-openssl-dev git && cd /root && git clone https://github.com/sergey-dryabzhinsky/nginx-rtmp-module.git && curl -o nginx.tar.gz http://nginx.org/download/nginx-1.14.0.tar.gz && mkdir nginx && tar xf nginx.tar.gz -C nginx --strip-components 1 && cd /root/nginx && ./configure --with-http_ssl_module --add-module=../nginx-rtmp-module && make -j 1 && make install && rm -rf /root/nginx && rm -rf /root/nginx-rtmp-module && rm /root/nginx.tar.gz && apt-get remove --purge -y git build-essential make gcc libpcre++-dev zlib1g-dev libbz2-dev libxslt1-dev libxml2-dev libgd2-xpm-dev libgeoip-dev libgoogle-perftools-dev libperl-dev libcurl4-openssl-dev && apt-get autoremove --purge -y && rm -rf /var/lib/apt/lists/*
 
 # Copy NGINX Configuration
 COPY resources/nginx.conf /usr/local/nginx/conf/nginx.conf

--- a/containers/nginx-rtsp/resources/entrypoint.sh
+++ b/containers/nginx-rtsp/resources/entrypoint.sh
@@ -11,7 +11,7 @@ for i in "${ADDR[@]}"; do
 CAMUSERNAME=$(echo "$i" | cut -d: -f1)
 CAMPASSWORD=$(echo "$i" | cut -d: -f2)
 
-Add Variable to .htpasswd
+# Add Variable to .htpasswd
 printf "$CAMUSERNAME:$(openssl passwd -crypt $CAMPASSWORD)\n" >> /usr/local/nginx/cameraauth.htpasswd
 
 done


### PR DESCRIPTION
This PR changes the following:

- Significantly reduces the size of the nginx-rtsp container (1/3 of original size)
- Significantly reduces the size of the ffmpeg container (1/3 of original size)
- Adds a missing \# to a comment in the nginx-rtsp entrypoint.sh